### PR TITLE
Fix CentOS Linux release 7.2.1511 (Core)

### DIFF
--- a/samples/config.ini-dist
+++ b/samples/config.ini-dist
@@ -11,7 +11,7 @@ host = 0.0.0.0
 interval = 5 ;Interval for request on seconds
 ;hide =  ; Hide queue on monitor separate by comma. Example config hide=queue1,queue2
 ;show = ; Add queue what you required to show. Example show=queue1,otherqueuename.
-        ; This option override the hide parameter
+;This option override the hide parameter
 ;base_url =  ; Default is /
 ;secret_key = 'PLEASE_CHANGE_ME' ; is a good idea change this value
 language = en


### PR DESCRIPTION
Lets say I docker pull centos and install qpanel. This is what I'll get. 

[root@7690ea82b551 qpanel]# pip install -r requirements.txt
Collecting Flask<0.12,>=0.11 (from -r requirements/base.txt (line 1))
  Downloading Flask-0.11.1-py2.py3-none-any.whl (80kB)
    100% |################################| 81kB 244kB/s
Collecting Flask_Babel>=0.9 (from -r requirements/base.txt (line 2))
  Downloading Flask-Babel-0.11.1.tar.gz (40kB)
    100% |################################| 40kB 1.5MB/s
Collecting Flask_Login>=0.3.2 (from -r requirements/base.txt (line 3))
  Downloading Flask_Login-0.4.0-py2.py3-none-any.whl
Collecting SQLAlchemy==0.9.10 (from -r requirements/base.txt (line 4))
  Downloading SQLAlchemy-0.9.10.tar.gz (4.3MB)
    100% |################################| 4.3MB 280kB/s
Collecting Click==6.6 (from -r requirements/base.txt (line 5))
  Downloading click-6.6-py2.py3-none-any.whl (71kB)
    100% |################################| 71kB 3.1MB/s
Collecting Tailer==0.4.1 (from -r requirements/base.txt (line 6))
  Downloading tailer-0.4.1.tar.gz
Collecting py-Asterisk from git+git://github.com/jeansch/py-asterisk@904c91c#egg=py-Asterisk (from -r requirements/base.txt (line 7))
  Cloning git://github.com/jeansch/py-asterisk (to 904c91c) to /tmp/pip-build-Et90x9/py-Asterisk
  Could not find a tag or branch '904c91c', assuming commit.
Collecting requests==2.11.1 (from -r requirements/base.txt (line 8))
  Downloading requests-2.11.1-py2.py3-none-any.whl (514kB)
    100% |################################| 522kB 1.0MB/s
Collecting future (from -r requirements/base.txt (line 9))
  Downloading future-0.16.0.tar.gz (824kB)
    100% |################################| 829kB 882kB/s
Collecting rq-scheduler<0.7.0,>=0.6.1 (from -r requirements/base.txt (line 10))
  Downloading rq_scheduler-0.6.1-py2.py3-none-any.whl
Collecting Jinja2>=2.4 (from Flask<0.12,>=0.11->-r requirements/base.txt (line 1))
  Downloading Jinja2-2.8-py2.py3-none-any.whl (263kB)
    100% |################################| 266kB 2.4MB/s
Collecting Werkzeug>=0.7 (from Flask<0.12,>=0.11->-r requirements/base.txt (line 1))
  Downloading Werkzeug-0.11.11-py2.py3-none-any.whl (306kB)
    100% |################################| 307kB 1.7MB/s
Collecting itsdangerous>=0.21 (from Flask<0.12,>=0.11->-r requirements/base.txt (line 1))
  Downloading itsdangerous-0.24.tar.gz (46kB)
    100% |################################| 51kB 4.1MB/s
Collecting Babel>=2.3 (from Flask_Babel>=0.9->-r requirements/base.txt (line 2))
  Downloading Babel-2.3.4-py2.py3-none-any.whl (7.1MB)
    100% |################################| 7.1MB 188kB/s
Collecting croniter>=0.3.9 (from rq-scheduler<0.7.0,>=0.6.1->-r requirements/base.txt (line 10))
  Downloading croniter-0.3.13-py2.py3-none-any.whl
Collecting rq>=0.3.5 (from rq-scheduler<0.7.0,>=0.6.1->-r requirements/base.txt (line 10))
  Downloading rq-0.7.0-py2.py3-none-any.whl (48kB)
    100% |################################| 51kB 4.0MB/s
Collecting MarkupSafe (from Jinja2>=2.4->Flask<0.12,>=0.11->-r requirements/base.txt (line 1))
  Downloading MarkupSafe-0.23.tar.gz
Collecting pytz>=0a (from Babel>=2.3->Flask_Babel>=0.9->-r requirements/base.txt (line 2))
  Downloading pytz-2016.10-py2.py3-none-any.whl (483kB)
    100% |################################| 491kB 1.5MB/s
Collecting python-dateutil (from croniter>=0.3.9->rq-scheduler<0.7.0,>=0.6.1->-r requirements/base.txt (line 10))
  Downloading python_dateutil-2.6.0-py2.py3-none-any.whl (194kB)
    100% |################################| 194kB 2.8MB/s
Collecting redis>=2.7.0 (from rq>=0.3.5->rq-scheduler<0.7.0,>=0.6.1->-r requirements/base.txt (line 10))
  Downloading redis-2.10.5-py2.py3-none-any.whl (60kB)
    100% |################################| 61kB 4.2MB/s
Collecting six>=1.5 (from python-dateutil->croniter>=0.3.9->rq-scheduler<0.7.0,>=0.6.1->-r requirements/base.txt (line 10))
  Downloading six-1.10.0-py2.py3-none-any.whl
Building wheels for collected packages: Flask-Babel, SQLAlchemy, Tailer, future, itsdangerous, MarkupSafe
  Running setup.py bdist_wheel for Flask-Babel ... done
  Stored in directory: /root/.cache/pip/wheels/99/65/6c/927249178edfdc24c9cb2d9fcea27f598a73b323a1b5e3a8fc
  Running setup.py bdist_wheel for SQLAlchemy ... done
  Stored in directory: /root/.cache/pip/wheels/3e/73/b1/58b3b39f933998a7095db80a9a1f7871168f9bef50af4bd0c3
  Running setup.py bdist_wheel for Tailer ... done
  Stored in directory: /root/.cache/pip/wheels/86/30/e9/ea2c40a0b2cc6369a4d5ad033490d95f4cca5aa7dde15be7ff
  Running setup.py bdist_wheel for future ... done
  Stored in directory: /root/.cache/pip/wheels/c2/50/7c/0d83b4baac4f63ff7a765bd16390d2ab43c93587fac9d6017a
  Running setup.py bdist_wheel for itsdangerous ... done
  Stored in directory: /root/.cache/pip/wheels/fc/a8/66/24d655233c757e178d45dea2de22a04c6d92766abfb741129a
  Running setup.py bdist_wheel for MarkupSafe ... done
  Stored in directory: /root/.cache/pip/wheels/a3/fa/dc/0198eed9ad95489b8a4f45d14dd5d2aee3f8984e46862c5748
Successfully built Flask-Babel SQLAlchemy Tailer future itsdangerous MarkupSafe
Installing collected packages: Click, MarkupSafe, Jinja2, Werkzeug, itsdangerous, Flask, pytz, Babel, Flask-Babel, Flask-Login, SQLAlchemy, Tailer, py-Asterisk, requests, future, six, python-dateutil, croniter, redis, rq, rq-scheduler
  Running setup.py install for py-Asterisk ... done
Successfully installed Babel-2.3.4 Click-6.6 Flask-0.11.1 Flask-Babel-0.11.1 Flask-Login-0.4.0 Jinja2-2.8 MarkupSafe-0.23 SQLAlchemy-0.9.10 Tailer-0.4.1 Werkzeug-0.11.11 croniter-0.3.13 future-0.16.0 itsdangerous-0.24 py-Asterisk-0.5.8 python-dateutil-2.6.0 pytz-2016.10 redis-2.10.5 requests-2.11.1 rq-0.7.0 rq-scheduler-0.6.1 six-1.10.0
[root@7690ea82b551 qpanel]# python app.py
Traceback (most recent call last):
  File "app.py", line 1, in <module>
    from qpanel import app
  File "/usr/src/qpanel/qpanel/app.py", line 22, in <module>
    if QPanelConfig().has_queuelog_config():
  File "/usr/src/qpanel/qpanel/config.py", line 32, in __init__
    self.config = self.__open_config_file(self.path_config_file)
  File "/usr/src/qpanel/qpanel/config.py", line 62, in __open_config_file
    raise NotConfigFileQPanel(file_path)
qpanel.config.NotConfigFileQPanel: Error to open file config. Check if /usr/src/qpanel/qpanel/../config.ini file exist
[root@7690ea82b551 qpanel]# python -V
Python 2.7.5
[root@7690ea82b551 qpanel]# find . -name '*.ini'
./samples/configs/uwsgi-qpanel.ini
./tox.ini
[root@7690ea82b551 qpanel]# pwd
/usr/src/qpanel
[root@7690ea82b551 qpanel]# ls -ltr
total 1636
drwxr-xr-x 1 root root     108 Dec 10 21:42 doc
-rw-r--r-- 1 root root    3228 Dec 10 21:42 code_of_conduct.md
-rw-r--r-- 1 root root     827 Dec 10 21:42 bower.json
-rw-r--r-- 1 root root      35 Dec 10 21:42 app.py
-rw-r--r-- 1 root root      11 Dec 10 21:42 VERSION
-rw-r--r-- 1 root root    4138 Dec 10 21:42 README.md
-rw-r--r-- 1 root root    1099 Dec 10 21:42 LICENSE
-rw-r--r-- 1 root root   18613 Dec 10 21:42 CHANGELOG.md
drwxr-xr-x 1 root root      54 Dec 10 21:42 patches
-rw-r--r-- 1 root root    1633 Dec 10 21:42 parser_queuelog.py
-rw-r--r-- 1 root root     357 Dec 10 21:42 package.json
-rw-r--r-- 1 root root      74 Dec 10 21:42 run_test.sh
-rw-r--r-- 1 root root      25 Dec 10 21:42 requirements.txt
drwxr-xr-x 1 root root      46 Dec 10 21:42 requirements
-rw-r--r-- 1 root root     370 Dec 10 21:42 update_config.py
-rw-r--r-- 1 root root     134 Dec 10 21:42 tox.ini
drwxr-xr-x 1 root root      88 Dec 10 21:42 tests
-rw-r--r-- 1 root root     146 Dec 10 21:42 start.wsgi
drwxr-xr-x 1 root root     168 Dec 10 21:42 samples
-rw-r--r-- 1 root root 1595408 Dec 10 21:45 get-pip.py
drwxr-xr-x 1 root root     564 Dec 10 21:46 qpanel
[root@7690ea82b551 qpanel]#  cp samples/config.ini-dist config.ini
[root@7690ea82b551 qpanel]# python app.py
Traceback (most recent call last):
  File "app.py", line 1, in <module>
    from qpanel import app
  File "/usr/src/qpanel/qpanel/app.py", line 22, in <module>
    if QPanelConfig().has_queuelog_config():
  File "/usr/src/qpanel/qpanel/config.py", line 48, in __init__
    = self.__get_entry_int_min_value('general', 'interval', 1)
  File "/usr/src/qpanel/qpanel/config.py", line 93, in __get_entry_int_min_value
    v = int(self.__get_entry_ini_default(section, option, min))
ValueError: invalid literal for int() with base 10: '5\n; This option override the hide parameter'

[root@7690ea82b551 qpanel]# grep 'hide'  config.ini
;hide =  ; Hide queue on monitor separate by comma. Example config hide=queue1,queue2
        ; This option override the hide parameter

But if I edit 'config.ini'

[root@7690ea82b551 qpanel]# grep hide  config.ini
;hide =  ; Hide queue on monitor separate by comma. Example config hide=queue1,queue2
; This option override the hide parameter

[root@7690ea82b551 qpanel]# python app.py
 * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)