### PR TITLE
Adding python-ESL as base requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ branches:
   only:
     - master
 script: tox
+addons:
+  apt:
+    packages:
+    - swig

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,3 +8,4 @@ git+git://github.com/jeansch/py-asterisk@904c91c#egg=py-Asterisk
 requests==2.11.1
 future
 rq-scheduler>=0.6.1,<0.7.0
+python-ESL==1.4.18


### PR DESCRIPTION
Easier to start qpanel with FreeSWITCH, installing the ESL from https://github.com/sangoma/python-ESL
To avoid:

`File "app.py", line 31, in <module>
    backend = Backend()
  File "/usr/src/qpanel/libs/qpanel/backend.py", line 36, in init
    self.connection = self._connect()
  File "/usr/src/qpanel/libs/qpanel/backend.py", line 46, in _connect
    return self._connect_esl()
  File "/usr/src/qpanel/libs/qpanel/backend.py", line 54, in _connect_esl
    esl = Freeswitch(self.host, self.port, self.password)
NameError: global name 'Freeswitch' is not defined`

And not force users to make pymod-install with FreeSWITCH src code.

:)